### PR TITLE
전방 선언으로 인한 순환 참조 에러가 무시되어 C4430 에러가 발생하면서 프로젝트가 빌드가 안되는 문제 수정

### DIFF
--- a/Source/ProjectISG/Systems/Grid/Manager/GridManager.cpp
+++ b/Source/ProjectISG/Systems/Grid/Manager/GridManager.cpp
@@ -18,8 +18,6 @@ void AGridManager::BeginPlay()
 {
 	Super::BeginPlay();
 
-	PlacementGridContainer.SetOwner(this);
-
 	if (!HasAuthority())
 	{
 		Destroy();

--- a/Source/ProjectISG/Systems/Grid/Manager/GridManager.h
+++ b/Source/ProjectISG/Systems/Grid/Manager/GridManager.h
@@ -6,7 +6,6 @@
 #include "GridManager.generated.h"
 
 UCLASS()
-
 class PROJECTISG_API AGridManager : public AActor
 {
 	GENERATED_BODY()

--- a/Source/ProjectISG/Systems/Grid/PlacementGridContainer.cpp
+++ b/Source/ProjectISG/Systems/Grid/PlacementGridContainer.cpp
@@ -1,6 +1,13 @@
 ﻿#include "PlacementGridContainer.h"
-#include "Actors/Placement.h"
-#include "Manager/GridManager.h"
+
+template<>
+struct TStructOpsTypeTraits<FPlacementGridContainer> : TStructOpsTypeTraitsBase2<FPlacementGridContainer>
+{
+	enum
+	{
+		WithNetDeltaSerializer = true
+	};
+};
 
 bool FPlacementGridContainer::NetDeltaSerialize(FNetDeltaSerializeInfo& DeltaParms)
 {
@@ -23,12 +30,6 @@ void FPlacementGridContainer::Add(const FIntVector& GridCoord, APlacement* Place
 	Items.Add(Entry);
 
 	MarkItemDirty(Entry);
-
-	if (Owner)
-	{
-		// Clone Trigger
-		Owner->ForceNetUpdate();
-	}
 
 	PlacedMap.Add(GridCoord, Placement);
 }
@@ -75,12 +76,3 @@ FItemMetaInfo FPlacementGridContainer::Remove(APlacement* Placement)
 
 	return ItemMetaInfo;
 }
-
-// template<>
-// struct TStructOpsTypeTraits<FPlacementGridContainer> : TStructOpsTypeTraitsBase2<FPlacementGridContainer>
-// {
-// 	enum
-// 	{
-// 		WithNetDeltaSerializer = true
-// 	};
-// };

--- a/Source/ProjectISG/Systems/Grid/PlacementGridContainer.h
+++ b/Source/ProjectISG/Systems/Grid/PlacementGridContainer.h
@@ -3,6 +3,7 @@
 #include "CoreMinimal.h"
 #include "Net/Serialization/FastArraySerializer.h"
 #include "ProjectISG/Systems/Inventory/ItemData.h"
+#include "Actors/Placement.h"
 #include "ProjectISG/Utils/MacroUtil.h"
 #include "PlacementGridContainer.generated.h"
 
@@ -15,7 +16,7 @@ struct FPlacementGridEntry : public FFastArraySerializerItem
 	FIntVector GridCoord;
 
 	UPROPERTY()
-	TWeakObjectPtr<class APlacement> Placement;
+	TWeakObjectPtr<APlacement> Placement;
 
 	UPROPERTY()
 	FItemMetaInfo ItemMetaInfo;
@@ -32,29 +33,25 @@ struct FPlacementGridContainer : public FFastArraySerializer
 	GENERATED_BODY()
 
 	GETTER(TArray<FPlacementGridEntry>, Items)
-	SETTER(class AGridManager*, Owner)
 
 	bool NetDeltaSerialize(FNetDeltaSerializeInfo& DeltaParms);
 
-	void Add(const FIntVector& GridCoord, class APlacement* Placement, FItemMetaInfo ItemMetaInfo);
+	void Add(const FIntVector& GridCoord, APlacement* Placement, FItemMetaInfo ItemMetaInfo);
 
-	FItemMetaInfo Remove(class APlacement* Placement);
+	FItemMetaInfo Remove(APlacement* Placement);
 
-	TMap<FIntVector, TWeakObjectPtr<class APlacement>> GetPlacedMap() const
+	TMap<FIntVector, TWeakObjectPtr<APlacement>> GetPlacedMap() const
 	{
 		return PlacedMap;
 	}
 
 protected:
-	UPROPERTY(NotReplicated)
-	class AGridManager* Owner = nullptr;
-	
 	UPROPERTY()
 	TArray<FPlacementGridEntry> Items;
 
 	//빠른 접근용 Cache Map
 	UPROPERTY(NotReplicated)
-	TMap<FIntVector, TWeakObjectPtr<class APlacement>> PlacedMap;
+	TMap<FIntVector, TWeakObjectPtr<APlacement>> PlacedMap;
 
-	TMap<TWeakObjectPtr<class APlacement>, TArray<FIntVector>> ReverseMap;
+	TMap<TWeakObjectPtr<APlacement>, TArray<FIntVector>> ReverseMap;
 };


### PR DESCRIPTION
순환 참조가 발생해야하는 곳에 전방 선언으로 넘겨버려 형식 지정자가 누락되었다고 판단하고 에러를 뱉게 되는 것이 원인